### PR TITLE
Split into modules for easier maintainability

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,11 @@
-#!/usr/bin/env node
 import fs from 'fs';
-import { program } from 'commander';
 
-program
-  .name('jsc')
-  .description('A 🔥 BLAZINGLY FAST 🔥, but ❄️ refreshingly simple ❄️ JavaScript to JavaScript compiler')
-  .version('1.0.1')
-  .argument('<input>')
-  .requiredOption('-o <output>');
-
-program.parse();
-const options = program.opts();
-
-const input = program.args[0];
-const output = options.o;
-
-fs.cpSync(input, output);
+/**
+ * Perform a 🔥 BLAZINGLY FAST 🔥 compilations of the given input and output
+ * files
+ * @param {string} input input file name or directory name
+ * @param {string} output output file name or directory name
+ */
+export function compile(input, output) {
+  fs.cpSync(input, output);
+}

--- a/jsc.js
+++ b/jsc.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+/**
+ * The main entrypoint to the JSC compiler, accessed by running `jsc`
+ */
+import { program } from 'commander';
+import { compile } from './index.js';
+
+/**
+ * Main function
+ */
+function main() {
+  program
+    .name('jsc')
+    .description('A 🔥 BLAZINGLY FAST 🔥, but ❄️ refreshingly simple ❄️ JavaScript to JavaScript compiler')
+    .version('1.0.1')
+    .argument('<input>')
+    .requiredOption('-o <output>');
+
+  program.parse();
+  const options = program.opts();
+
+  const input = program.args[0];
+  const output = options.o;
+
+  compile(input, output);
+}
+
+
+main();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "bin": {
-    "jsc": "index.js"
+    "jsc": "jsc.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Even for simple codebases, unlike Babel and TypeScript, it's important to write well-designed code